### PR TITLE
[fix] Add error handling for empty or missing response

### DIFF
--- a/src/GeetestCaptcha.php
+++ b/src/GeetestCaptcha.php
@@ -55,7 +55,7 @@ class GeetestCaptcha
         $obj = json_decode($res, true);
         $this->validatedData = $obj;
 
-        if (empty($obj) or !isset($obj['result'])) {
+        if (empty($obj) or ! isset($obj['result'])) {
             return false;
         }
 

--- a/src/GeetestCaptcha.php
+++ b/src/GeetestCaptcha.php
@@ -55,6 +55,10 @@ class GeetestCaptcha
         $obj = json_decode($res, true);
         $this->validatedData = $obj;
 
+        if (empty($obj) or !isset($obj['result'])) {
+            return false;
+        }
+
         if ($obj['result'] != 'success') {
             return false;
         }


### PR DESCRIPTION
This pull request includes a small but important change to the `validate` function in the `src/GeetestCaptcha.php` file. The change adds a check to ensure that the response object is not empty and contains the 'result' key before proceeding with validation.

* [`src/GeetestCaptcha.php`](diffhunk://#diff-2186200362399130b5cbdb9144ab2fea66746e1d974b0d5f0043e07f9c6c5ab6R58-R61): Added a check to return `false` if the response object is empty or does not contain the 'result' key in the `validate` function.